### PR TITLE
Uninstall existing copies of 7-Zip

### DIFF
--- a/repository/7-zip/x64/7-Zip x64.bat
+++ b/repository/7-zip/x64/7-Zip x64.bat
@@ -46,6 +46,11 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall other versions of 7-zip
+IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+wmic product where "name like '7-Zip%%'" uninstall /nointeractive
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 

--- a/repository/7-zip/x86/7-Zip x86.bat
+++ b/repository/7-zip/x86/7-Zip x86.bat
@@ -46,6 +46,11 @@ pushd "%~dp0"
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall existing copies of 7-Zip
+IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+wmic product where "name like '7-Zip%%'" uninstall /nointeractive
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 


### PR DESCRIPTION
Uninstall existing copies of 7-zip before installing 7-Zip x64.

The installer itself doesn't seem to remove previous versions, or at least not those installed from 7-zip.org or through ninite.com