### PR TITLE
Fully remove old installs of Firefox

### DIFF
--- a/repository/mozilla/firefox/x64/Firefox.bat
+++ b/repository/mozilla/firefox/x64/Firefox.bat
@@ -46,6 +46,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)

--- a/repository/mozilla/firefox/x86/Firefox x86.bat
+++ b/repository/mozilla/firefox/x86/Firefox x86.bat
@@ -46,6 +46,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)

--- a/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
+++ b/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
@@ -50,6 +50,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)

--- a/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
+++ b/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
@@ -49,6 +49,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)


### PR DESCRIPTION
The `wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive` line was not removing all copies of Firefox before the new version was installed for me.

I have added the specific x86 and x64 `helper.exe /S` Firefox uninstall commands to all 4 Firefox `. bat` installations scripts.