### PR TITLE
Uninstall existing copies of 7-Zip

### DIFF
--- a/repository/7-zip/x64/7-Zip x64.bat
+++ b/repository/7-zip/x64/7-Zip x64.bat
@@ -46,6 +46,11 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall other versions of 7-zip
+IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+wmic product where "name like '7-Zip%%'" uninstall /nointeractive
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 

--- a/repository/7-zip/x86/7-Zip x86.bat
+++ b/repository/7-zip/x86/7-Zip x86.bat
@@ -46,6 +46,11 @@ pushd "%~dp0"
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall existing copies of 7-Zip
+IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+wmic product where "name like '7-Zip%%'" uninstall /nointeractive
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 


### PR DESCRIPTION
Before installing a new 7-Zip, uninstall existing copies.

The 7-zip installer itself doesn't remove old version, and instead installs next to 7-Zip installed from 7-zip.org and ninite.com.

Sorry for the two original pull request for 7-zip. I've merged those two pull requests for the x86 and x68 `.bat` files into this one pull request.