### PR TITLE
Firefox icon name change

### DIFF
--- a/repository/7-zip/x64/7-Zip x64.bat
+++ b/repository/7-zip/x64/7-Zip x64.bat
@@ -1,7 +1,8 @@
 :: Purpose:       Installs a package
 :: Requirements:  Run this script with Administrator rights
 :: Author:        vocatus on reddit.com/r/sysadmin ( vocatus.gate@gmail.com ) // PGP key ID: 0x07d1490f82a211a2
-:: History:       1.0.0 + Initial write
+:: History:       1.0.1 - Remove old versions first. Thanks to github:abulgatz
+::                1.0.0 + Initial write
 
 :: Usage:         Run the script and pass one of the following arguments to it:
 ::                  associate_common  Associate 7-Zip with the common file compression formats 
@@ -17,8 +18,8 @@
 :: Prep :: -- Don't change anything in this section
 ::::::::::
 @echo off
-set SCRIPT_VERSION=1.0.0
-set SCRIPT_UPDATED=2015-01-06
+set SCRIPT_VERSION=1.0.1
+set SCRIPT_UPDATED=2019-05-14
 :: Get the date into ISO 8601 standard date format (yyyy-mm-dd) so we can use it
 FOR /f %%a in ('WMIC OS GET LocalDateTime ^| find "."') DO set DTS=%%a
 set CUR_DATE=%DTS:~0,4%-%DTS:~4,2%-%DTS:~6,2%
@@ -36,7 +37,7 @@ set LOGFILE=
 
 :: Package to install. Do not use trailing slashes (\)
 set LOCATION=
-set BINARY=7-Zip v16.02 x64.msi
+set BINARY=7-Zip v19.00 x64.msi
 set FLAGS=ALLUSERS=1 /q /norestart INSTALLDIR="C:\Program Files\7-Zip"
 
 :: Create the log directory if it doesn't exist

--- a/repository/7-zip/x64/7-Zip x64.bat
+++ b/repository/7-zip/x64/7-Zip x64.bat
@@ -46,6 +46,11 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall other versions of 7-zip
+IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+wmic product where "name like '7-Zip%%'" uninstall /nointeractive
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 

--- a/repository/7-zip/x86/7-Zip x86.bat
+++ b/repository/7-zip/x86/7-Zip x86.bat
@@ -1,14 +1,15 @@
 :: Purpose:       Installs a package
 :: Requirements:  Run this script with Administrator rights
 :: Author:        vocatus on reddit.com/r/sysadmin ( vocatus.gate@gmail.com ) // PGP key ID: 0x07d1490f82a211a2
-:: History:       1.0.0 + Initial write
+:: History:       1.0.1 - Remove old versions first. Thanks to github:abulgatz
+::                1.0.0 + Initial write
 
 :: Usage:         Run the script and pass one of the following arguments to it:
 ::                  associate_common  Associate 7-Zip with the common file compression formats 
 ::                                     (7z,bz2,bzip2,gz,gzip,lzh,lzma,rar,tar,tgz,zip)
 ::                  associate_all     Associate 7-zip with ALL the file compression formats it supports
 ::
-::                e.g. 7-Zip v9.20 x86.bat associate_all  
+::                e.g. 7-Zip v9.36 x86.bat associate_all  
 ::
 ::                Default is "associate_common" unless told otherwise
 
@@ -17,8 +18,8 @@
 :: Prep :: -- Don't change anything in this section
 ::::::::::
 @echo off
-set SCRIPT_VERSION=1.0.0
-set SCRIPT_UPDATED=2015-01-06
+set SCRIPT_VERSION=1.0.1
+set SCRIPT_UPDATED=2019-05-14
 :: Get the date into ISO 8601 standard date format (yyyy-mm-dd) so we can use it
 FOR /f %%a in ('WMIC OS GET LocalDateTime ^| find "."') DO set DTS=%%a
 set CUR_DATE=%DTS:~0,4%-%DTS:~4,2%-%DTS:~6,2%
@@ -33,7 +34,7 @@ set LOGFILE=
 
 :: Package to install. Do not use trailing slashes (\)
 set LOCATION=
-set BINARY=7-Zip v16.02 x86.msi
+set BINARY=7-Zip v19.00 x86.msi
 set FLAGS=ALLUSERS=1 /q /norestart INSTALLDIR="C:\Program Files\7-Zip"
 
 :: Create the log directory if it doesn't exist
@@ -46,7 +47,7 @@ pushd "%~dp0"
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
-:: Uninstall existing copies of 7-Zip
+:: Uninstall other versions of 7-zip
 IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
 IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
 wmic product where "name like '7-Zip%%'" uninstall /nointeractive

--- a/repository/7-zip/x86/7-Zip x86.bat
+++ b/repository/7-zip/x86/7-Zip x86.bat
@@ -46,6 +46,11 @@ pushd "%~dp0"
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall existing copies of 7-Zip
+IF EXIST "%ProgramFiles%\7-Zip\Uninstall.exe" "%ProgramFiles%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+IF EXIST "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" "%ProgramFiles(x86)%\7-Zip\Uninstall.exe" /S /V"/qn /norestart"
+wmic product where "name like '7-Zip%%'" uninstall /nointeractive
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 

--- a/repository/adobe/acrobat_reader_dc/x86/Adobe Acrobat Reader DC.bat
+++ b/repository/adobe/acrobat_reader_dc/x86/Adobe Acrobat Reader DC.bat
@@ -1,7 +1,8 @@
 :: Purpose:       Installs a package
 :: Requirements:  Run this script with Administrator rights
 :: Author:        vocatus on reddit.com/r/sysadmin ( vocatus.gate@gmail.com ) // PGP key ID: 0x07d1490f82a211a2
-:: Version:       1.0.5 + Add removal of previous installations prior to running new installation. Thanks to u/devoar999
+:: Version:       1.0.6 + Add deletion of the desktop icon. Thanks to github:abulgatz
+::                1.0.5 + Add removal of previous installations prior to running new installation. Thanks to u/devoar999
 ::                1.0.4 + Add associating PDF files to Acrobat after installation. Thanks to u/dimm0k
 ::                1.0.3 + Add killing of Chrome Acrobat plugin registry entry
 ::                1.0.2 + Add killing of additional Updater registry keys
@@ -14,8 +15,8 @@
 :: Prep :: -- Don't change anything in this section
 ::::::::::
 @echo off
-set SCRIPT_VERSION=1.0.5
-set SCRIPT_UPDATED=2018-10-16
+set SCRIPT_VERSION=1.0.6
+set SCRIPT_UPDATED=2019-05-14
 :: Get the date into ISO 8601 standard date format (yyyy-mm-dd) so we can use it
 FOR /f %%a in ('WMIC OS GET LocalDateTime ^| find "."') DO set DTS=%%a
 set CUR_DATE=%DTS:~0,4%-%DTS:~4,2%-%DTS:~6,2%

--- a/repository/adobe/acrobat_reader_dc/x86/Adobe Acrobat Reader DC.bat
+++ b/repository/adobe/acrobat_reader_dc/x86/Adobe Acrobat Reader DC.bat
@@ -83,6 +83,9 @@ if exist "%ProgramFiles(x86)%\Adobe\Acrobat 7.0\Distillr\acrotray.exe" (
 	del /f /q "%ProgramFiles(x86)%\Adobe\Acrobat 7.0\Distillr\acrotray.exe" >> "%LOGPATH%\%LOGFILE%" 2>NUL
 )
 
+:: Delete the desktop icon
+if exist "%PUBLIC%\Desktop\Acrobat Reader DC.lnk" del /f "%PUBLIC%\Desktop\Acrobat Reader DC.lnk"
+
 :: Delete the stupid Chrome plugin Adobe loads without our consent
 reg delete HKEY_LOCAL_MACHINE\SOFTWARE\Wow6432Node\Google\Chrome\Extensions\efaidnbmnnnibpcajpcglclefindmkaj /f >> "%LOGPATH%\%LOGFILE%" 2>NUL
 

--- a/repository/mozilla/firefox/x64/Firefox.bat
+++ b/repository/mozilla/firefox/x64/Firefox.bat
@@ -46,6 +46,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)

--- a/repository/mozilla/firefox/x64/Firefox.bat
+++ b/repository/mozilla/firefox/x64/Firefox.bat
@@ -63,7 +63,7 @@ REM if exist "%public%\Desktop\Mozilla Firefox.lnk" del "%public%\Desktop\Mozill
 REM if exist "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk" del "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk"
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd

--- a/repository/mozilla/firefox/x86/Firefox x86.bat
+++ b/repository/mozilla/firefox/x86/Firefox x86.bat
@@ -46,6 +46,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)

--- a/repository/mozilla/firefox/x86/Firefox x86.bat
+++ b/repository/mozilla/firefox/x86/Firefox x86.bat
@@ -63,7 +63,7 @@ REM if exist "%public%\Desktop\Mozilla Firefox.lnk" del "%public%\Desktop\Mozill
 REM if exist "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk" del "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk"
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd

--- a/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
+++ b/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
@@ -69,7 +69,7 @@ if %PRESERVE_SHORTCUTS%==no (
 )
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd

--- a/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
+++ b/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
@@ -50,6 +50,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)

--- a/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
+++ b/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
@@ -49,6 +49,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 wmic process where name="firefox.exe" call terminate 2>NUL
 
 :: Remove old version first
+IF EXIST "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles%\Mozilla Firefox\uninstall\helper.exe" /S
+IF EXIST "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" "%ProgramFiles(x86)%\Mozilla Firefox\uninstall\helper.exe" /S
 wmic product where "name like 'Mozille Firefox%%'" call uninstall /nointeractive
 
 :: Install the package from the local folder (if all files are in the same directory)

--- a/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
+++ b/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
@@ -68,7 +68,7 @@ if %PRESERVE_SHORTCUTS%==no (
 )
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd

--- a/repository/vlc/x86/vlc.bat
+++ b/repository/vlc/x86/vlc.bat
@@ -38,6 +38,10 @@ if not exist %LOGPATH% mkdir %LOGPATH
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
+:: Uninstall VLC
+if exist "%PROGRAMFILES%\VideoLAN\VLC\uninstall.exe" "%PROGRAMFILES%\VideoLAN\VLC\uninstall.exe" /S
+if exist "%PROGRAMFILES(x86)%\VideoLAN\VLC\uninstall.exe" "%PROGRAMFILES(x86)%\VideoLAN\VLC\uninstall.exe" /S
+
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%
 

--- a/repository/vlc/x86/vlc.bat
+++ b/repository/vlc/x86/vlc.bat
@@ -1,15 +1,16 @@
 :: Purpose:       Installs a package
 :: Requirements:  Run this script with Administrator rights
 :: Author:        vocatus on reddit.com/r/sysadmin ( vocatus.gate@gmail.com ) // PGP key ID: 0x07d1490f82a211a2
-:: History:       1.0.0 + Initial write
+:: History:       1.0.1 + Add uninstallation of previous versions prior to installing. Thanks to github:abulgatz
+::                1.0.0 + Initial write
 
 
 ::::::::::
 :: Prep :: -- Don't change anything in this section
 ::::::::::
 @echo off
-set SCRIPT_VERSION=1.0.0
-set SCRIPT_UPDATED=2015-07-18
+set SCRIPT_VERSION=1.0.1
+set SCRIPT_UPDATED=2019-05-14
 :: Get the date into ISO 8601 standard date format (yyyy-mm-dd) so we can use it
 FOR /f %%a in ('WMIC OS GET LocalDateTime ^| find "."') DO set DTS=%%a
 set CUR_DATE=%DTS:~0,4%-%DTS:~4,2%-%DTS:~6,2%
@@ -29,7 +30,7 @@ set LOGFILE=
 
 :: Package to install. Do not use trailing slashes (\)
 set LOCATION=
-set BINARY=VLC v2.2.4 x86.exe
+set BINARY=VLC v3.0.6 x86.exe
 set FLAGS=ALLUSERS=1 /L=1033 /S INSTALLDIR="C:\Program Files (x86)\VLC"
 
 :: Create the log directory if it doesn't exist
@@ -38,9 +39,11 @@ if not exist %LOGPATH% mkdir %LOGPATH
 ::::::::::::::::::
 :: INSTALLATION ::
 ::::::::::::::::::
-:: Uninstall VLC
+
+:: Uninstall old versions first
 if exist "%PROGRAMFILES%\VideoLAN\VLC\uninstall.exe" "%PROGRAMFILES%\VideoLAN\VLC\uninstall.exe" /S
 if exist "%PROGRAMFILES(x86)%\VideoLAN\VLC\uninstall.exe" "%PROGRAMFILES(x86)%\VideoLAN\VLC\uninstall.exe" /S
+
 
 :: Install the package from the local folder (if all files are in the same directory)
 "%BINARY%" %FLAGS%


### PR DESCRIPTION
Mozilla has updated the Firefox icon name from `Mozilla Firefox.lnk` to just `Firefox.lnk`. I have updated the scripts to find the new icons.

I'm not a huge fan of searching all user profile folders for Firefox shortcuts, as this can be very slow. I might write something to search all of the locations the icon should be in Windows 10.

The icon-finding in the ESR and non-ESR scripts also doesn't match, with the ESR script having a icon parameter that is partially ignored.