### PR TITLE
Firefox icon name changed

### DIFF
--- a/repository/mozilla/firefox/x64/Firefox.bat
+++ b/repository/mozilla/firefox/x64/Firefox.bat
@@ -63,7 +63,7 @@ REM if exist "%public%\Desktop\Mozilla Firefox.lnk" del "%public%\Desktop\Mozill
 REM if exist "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk" del "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk"
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd

--- a/repository/mozilla/firefox/x86/Firefox x86.bat
+++ b/repository/mozilla/firefox/x86/Firefox x86.bat
@@ -63,7 +63,7 @@ REM if exist "%public%\Desktop\Mozilla Firefox.lnk" del "%public%\Desktop\Mozill
 REM if exist "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk" del "%SystemDrive%\users\default\Desktop\Mozilla Firefox.lnk"
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd

--- a/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
+++ b/repository/mozilla/firefox_esr/x64/Firefox ESR.bat
@@ -69,7 +69,7 @@ if %PRESERVE_SHORTCUTS%==no (
 )
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd

--- a/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
+++ b/repository/mozilla/firefox_esr/x86/Firefox ESR x86.bat
@@ -68,7 +68,7 @@ if %PRESERVE_SHORTCUTS%==no (
 )
 
 :: Lets just amp this up and catch ANYWHERE it might drop a shortcut 
-del /f /s "%SystemDrive%\Users\*Mozilla Firefox.lnk" 2>nul
+del /f /s "%SystemDrive%\Users\*Firefox.lnk" 2>nul
 
 :: Pop back to original directory. This isn't necessary in stand-alone runs of the script, but is needed when being called from another script
 popd


### PR DESCRIPTION
Mozilla has updated the Firefox icon name from `Mozilla Firefox.lnk` to just `Firefox.lnk`. I have updated the scripts to find the new icons.

I'm not a huge fan of searching all user profile folders for Firefox shortcuts, as this can be very slow. I might write something to search all of the locations the icon should be in Windows 10.

The icon-finding in the ESR and non-ESR scripts also doesn't match, with the ESR script having a icon parameter that is partially broken/ignored.

Commit `9bc980f` should have been named `firefox esr x64 update icon name` (not x86). One commit per batch file.

Sorry for the earlier closed commit, had an issue rebasing my forked repo with your upstream changes.