### PR TITLE
Chrome - uninstall before installing

### DIFF
--- a/repository/google/chrome_enterprise/x64/googlechromestandaloneenterprise.bat
+++ b/repository/google/chrome_enterprise/x64/googlechromestandaloneenterprise.bat
@@ -48,6 +48,9 @@ cls
 %SystemDrive%\windows\system32\taskkill.exe /F /IM chrome.exe /T 2>NUL
 wmic process where name="chrome.exe" call terminate 2>NUL
 
+:: Uninstall existing versions of Chrome by calling powershell script
+PowerShell.exe -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File "uninstall-chrome.ps1"
+
 :: Install package from local directory (if all files are in the same directory)
 msiexec.exe /i "googlechromestandaloneenterprise.msi" %FLAGS%
 

--- a/repository/google/chrome_enterprise/x64/uninstall-chrome.ps1
+++ b/repository/google/chrome_enterprise/x64/uninstall-chrome.ps1
@@ -1,0 +1,21 @@
+# Originally found at this link: https://social.technet.microsoft.com/Forums/ie/en-US/7e3c5fd3-e41c-4a0c-88fd-90ec7520edde/how-can-i-uninstall-google-chrome-using-power-shell?forum=winserverpowershell
+# but have also seen the same script in several other places, not sure of original authors
+
+# WMI Method
+if($AppInfo = Get-WmiObject Win32_Product -Filter "Name Like 'Google Chrome'"){
+	& ${env:WINDIR}\System32\msiexec /x $AppInfo.IdentifyingNumber /Quiet /Passive /NoRestart
+}
+
+# Remove 32-bit Chrome on 32-bit Windows and 64-bit Chrome on 64-bit Windows
+if($Reg32Key = Get-ItemProperty -path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome' -name Version -ErrorAction SilentlyContinue){
+	if($Ver32Path = $Reg32Key.Version){
+		& ${env:ProgramFiles}\Google\Chrome\Application\$Ver32Path\Installer\setup.exe --uninstall --multi-install --chrome --system-level --force-uninstall
+	}
+}
+
+# Remove 32-bit Chrome on 64-bit Windows
+if($Reg64Key = Get-ItemProperty -path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome' -name Version -ErrorAction SilentlyContinue){
+	if ($Ver64Path = $Reg64Key.Version){
+		& ${env:ProgramFiles(x86)}\Google\Chrome\Application\$Ver64Path\Installer\setup.exe --uninstall --multi-install --chrome --system-level --force-uninstall
+	}
+}

--- a/repository/google/chrome_enterprise/x86/googlechromestandaloneenterprise x86.bat
+++ b/repository/google/chrome_enterprise/x86/googlechromestandaloneenterprise x86.bat
@@ -48,6 +48,9 @@ cls
 %SystemDrive%\windows\system32\taskkill.exe /F /IM chrome.exe /T 2>NUL
 wmic process where name="chrome.exe" call terminate 2>NUL
 
+:: Uninstall existing versions of Chrome by calling powershell script
+PowerShell.exe -NoLogo -NonInteractive -NoProfile -ExecutionPolicy Bypass -File "uninstall-chrome.ps1"
+
 :: Install package from local directory (if all files are in the same directory)
 msiexec.exe /i "googlechromestandaloneenterprise %BINARY_VERSION%.msi" %FLAGS%
 

--- a/repository/google/chrome_enterprise/x86/uninstall-chrome.ps1
+++ b/repository/google/chrome_enterprise/x86/uninstall-chrome.ps1
@@ -1,0 +1,21 @@
+# Originally found at this link: https://social.technet.microsoft.com/Forums/ie/en-US/7e3c5fd3-e41c-4a0c-88fd-90ec7520edde/how-can-i-uninstall-google-chrome-using-power-shell?forum=winserverpowershell
+# but have also seen the same script in several other places, not sure of original authors
+
+# WMI Method
+if($AppInfo = Get-WmiObject Win32_Product -Filter "Name Like 'Google Chrome'"){
+	& ${env:WINDIR}\System32\msiexec /x $AppInfo.IdentifyingNumber /Quiet /Passive /NoRestart
+}
+
+# Remove 32-bit Chrome on 32-bit Windows and 64-bit Chrome on 64-bit Windows
+if($Reg32Key = Get-ItemProperty -path 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome' -name Version -ErrorAction SilentlyContinue){
+	if($Ver32Path = $Reg32Key.Version){
+		& ${env:ProgramFiles}\Google\Chrome\Application\$Ver32Path\Installer\setup.exe --uninstall --multi-install --chrome --system-level --force-uninstall
+	}
+}
+
+# Remove 32-bit Chrome on 64-bit Windows
+if($Reg64Key = Get-ItemProperty -path 'HKLM:\SOFTWARE\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Google Chrome' -name Version -ErrorAction SilentlyContinue){
+	if ($Ver64Path = $Reg64Key.Version){
+		& ${env:ProgramFiles(x86)}\Google\Chrome\Application\$Ver64Path\Installer\setup.exe --uninstall --multi-install --chrome --system-level --force-uninstall
+	}
+}


### PR DESCRIPTION
Chrome can be installed in many placed and in many ways, and Enterprise will install side-by-side instead of on top of many other Chrome installs.

Included a PowerShell script (called from the installer bat) to remove (hopefully) all previous versions of Chrome before installing Enterprise.