### PR TITLE
Update Google Earth Pro to v7.3.3

### DIFF
--- a/job_files/Installers.xml
+++ b/job_files/Installers.xml
@@ -1229,8 +1229,8 @@ Gimp v2.10.14 x86.exe /verysilent /norestart</Description>
         <IsAutoDownload value="false" />
         <FolderId value="4" />
         <LibraryPackageVersionId value="null" />
-        <Name>Google Earth Pro v7.3.2</Name>
-        <Path>Installers\Google Earth Pro v7.3.2</Path>
+        <Name>Google Earth Pro v7.3.3</Name>
+        <Path>Installers\Google Earth Pro v7.3.3</Path>
         <PackageDisplaySettings name="DisplaySettings">
           <DisplayType>Normal</DisplayType>
           <IconKey>Icon-Package</IconKey>

--- a/repository/google/earth_pro/x64/Google Earth Pro.bat
+++ b/repository/google/earth_pro/x64/Google Earth Pro.bat
@@ -2,7 +2,7 @@
 :: Requirements:  1. Run this script with Administrator rights
 :: Author:        vocatus on reddit.com/r/sysadmin ( vocatus.gate@gmail.com ) // PGP key ID: 0x07d1490f82a211a2
 :: History:       1.0.4 + Update installer to v7.3.3
-::								1.0.3 + Add proper console and logfile logging
+::                1.0.3 + Add proper console and logfile logging
 ::                1.0.2 + Add deletion of additional Google Update scheduled tasks
 ::                1.0.1 * Add command line argument to preserve shortcuts, default to False
 ::                1.0.0 + Initial write

--- a/repository/google/earth_pro/x64/Google Earth Pro.bat
+++ b/repository/google/earth_pro/x64/Google Earth Pro.bat
@@ -27,8 +27,8 @@ if not exist %LOGPATH% mkdir %LOGPATH%
 :: Prep :: -- Don't change anything in this section
 ::::::::::
 @echo off
-set SCRIPT_VERSION=1.0.3
-set SCRIPT_UPDATED=2020-02-05
+set SCRIPT_VERSION=1.0.4
+set SCRIPT_UPDATED=2020-06-12
 :: Get the date into ISO 8601 standard date format (yyyy-mm-dd) so we can use it
 FOR /f %%a in ('WMIC OS GET LocalDateTime ^| find "."') DO set DTS=%%a
 set CUR_DATE=%DTS:~0,4%-%DTS:~4,2%-%DTS:~6,2%

--- a/repository/google/earth_pro/x64/Google Earth Pro.bat
+++ b/repository/google/earth_pro/x64/Google Earth Pro.bat
@@ -1,7 +1,8 @@
 :: Purpose:       Installs a package
 :: Requirements:  1. Run this script with Administrator rights
 :: Author:        vocatus on reddit.com/r/sysadmin ( vocatus.gate@gmail.com ) // PGP key ID: 0x07d1490f82a211a2
-:: History:       1.0.3 + Add proper console and logfile logging
+:: History:       1.0.4 + Update installer to v7.3.3
+::								1.0.3 + Add proper console and logfile logging
 ::                1.0.2 + Add deletion of additional Google Update scheduled tasks
 ::                1.0.1 * Add command line argument to preserve shortcuts, default to False
 ::                1.0.0 + Initial write
@@ -15,7 +16,7 @@ set LOGPATH=%SystemDrive%\logs
 set LOGFILE=
 
 :: Package to install. Do not use trailing slashes (\)
-set BINARY=Google Earth Pro v7.3.2.exe
+set BINARY=Google Earth Pro v7.3.3.exe
 set FLAGS=OMAHA=1
 
 :: Create the log directory if it doesn't exist


### PR DESCRIPTION
Google Earth Pro has a new version (`7.3.2` -> `7.3.3`). Older versions prompt users for update.

Full offline installers:

- 64 bit: https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-7.3.3-x64.exe
- 32 bit: https://dl.google.com/dl/earth/client/advanced/current/googleearthprowin-7.3.3.exe